### PR TITLE
Feature/add ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,21 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: workout_nutrition
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -20,16 +35,5 @@ jobs:
           java-version: 21
           cache: maven
 
-      - name: Build project
-        run: mvn -B clean package
-
-      - name: Run tests
-        run: mvn test
-
-      - name: Publish Test Report
-        if: always()
-        uses: dorny/test-reporter@v1
-        with:
-          name: Maven Tests
-          path: target/surefire-reports/*.xml
-          reporter: java-junit
+      - name: Build and run tests
+        run: mvn -B verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
 
       - name: Build project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: Build project
+        run: mvn -B clean package
+
+      - name: Run tests
+        run: mvn test
+
+      - name: Publish Test Report
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: Maven Tests
+          path: target/surefire-reports/*.xml
+          reporter: java-junit

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/workout_nutrition
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Overview
This PR adds a Continuous Integration (CI) workflow using GitHub Actions to automatically build and test the project.

## Changes
- Added a CI workflow at `.github/workflows/ci.yml`
- Configured the workflow to run on `push` and `pull_request`
- Set up Java 21 using `actions/setup-java`
- Enabled Maven dependency caching to speed up CI builds
- Added a PostgreSQL service container in CI so integration tests can run against a real database
- Added test-specific configuration at `src/test/resources/application.properties` so tests connect to the CI PostgreSQL instance

## Result
- Every push or pull request now triggers the CI workflow
- The project is automatically built using Maven
- Tests run against a PostgreSQL database in CI
- CI verifies that the application builds and the test suite passes before changes are merged

closes #2 